### PR TITLE
Adjust card width for carousel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     }
 
     .card{
-      flex: 0 0 calc(100% - (2 * var(--peek)));
+      flex: 0 0 calc((100% - var(--gap)) / 2);
       background: var(--card);
       border: 1px solid rgba(255,255,255,.05);
       border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- update the carousel card flex-basis to use the gap value for width calculation, allowing two cards to fit per row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb12ee04908320ac6f11a557674217