### PR TITLE
Remove trust title from testimonial carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,8 +125,6 @@
 </head>
 <body>
   <div class="wrap">
-    <p class="title">Ils nous font confiance</p>
-
     <div class="carousel" aria-label="Carrousel de témoignages">
       <button class="nav prev" aria-label="Témoignages précédents">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>


### PR DESCRIPTION
## Summary
- remove the "Ils nous font confiance" heading from the testimonial carousel wrapper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb136f34c4832097b803c57c563433