### PR TITLE
Réduit la hauteur et les débordements de l'embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,30 +13,27 @@
       --muted: #9b9a97;
       --accent: #f1f1ef;
       --gap: 14px;
-      --peek: 40px;
+      --peek: 32px;
       --radius: 12px;
       --shadow: 0 18px 40px rgba(15,15,15,.55);
       --transition: 600ms cubic-bezier(.22,.61,.36,1);
+      --card-width: calc((100% - var(--gap)) / 2);
       color-scheme: dark;
     }
 
     * { box-sizing: border-box; }
-    html, body { height: 100%; }
 
     body{
       margin: 0;
-      min-height: 100dvh;
       background: var(--bg);
       color: var(--text);
       font: 16px/1.6 "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: clamp(32px, 6vh, 72px) 20px;
+      padding: clamp(20px, 4vh, 36px) clamp(16px, 4vw, 28px);
+      overflow-x: hidden;
     }
 
     .wrap{
-      width: min(520px, 100%);
+      width: min(500px, 100%);
       margin: 0 auto;
       display: grid;
       gap: 16px;
@@ -71,7 +68,7 @@
     }
 
     .card{
-      flex: 0 0 calc((100% - var(--gap)) / 2);
+      flex: 0 0 var(--card-width);
       background: var(--card);
       border: 1px solid rgba(255,255,255,.05);
       border-radius: var(--radius);
@@ -110,15 +107,23 @@
     .next{ right: 8px; }
     .nav svg{ width: 14px; height: 14px; color: var(--accent); }
 
-    @media (max-width: 540px){
-      :root{ --peek: 26px; }
-      body{ padding: 32px 16px; }
-      .wrap{ width: min(400px, 100%); }
+    @media (max-width: 600px){
+      :root{
+        --peek: 18px;
+        --gap: 12px;
+        --card-width: 100%;
+      }
+      body{ padding: clamp(18px, 5vh, 24px) 18px clamp(18px, 5vh, 24px); }
+      .wrap{ width: 100%; }
       .card{ min-height: 0; padding: 16px; }
     }
 
-    @media (max-width: 380px){
-      :root{ --peek: 18px; }
+    @media (max-width: 420px){
+      :root{ --peek: 14px; }
+    }
+
+    @media (max-width: 360px){
+      :root{ --peek: 12px; }
       .quote{ font-size: 15px; }
     }
   </style>


### PR DESCRIPTION
## Summary
- retire la hauteur forcée et le centrage vertical du `<body>` pour éviter le scroll interne dans un iframe étroit
- ajoute une largeur de carte réactive et réduit les "peek"/gaps afin de supprimer le débordement horizontal sur petits écrans
- compacte les espacements pour que le carrousel prenne moins de hauteur en intégration

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb152b2f908320a8df9c58a20d9adb